### PR TITLE
Fix typo in recortarCaracteres

### DIFF
--- a/server.R
+++ b/server.R
@@ -229,7 +229,7 @@ shinyServer(function(input, output,session) {
   
     umbralRecorte = 50 #máximo número de caracteres para display a full de niveles de variables categóricas
     recortarCaracteres <- function(x) {
-      if (nhcar(x)>umbralRecorte) {
+      if (nchar(x)>umbralRecorte) {
         x=paste(substr(x,0,umbralRecorte),"...",sep="")
       }
       return(x)


### PR DESCRIPTION
## Summary
- fix typo in helper function `recortarCaracteres`

## Testing
- `Rscript check_dependencias.r` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a770f92483259d39f0a8237ac3b4